### PR TITLE
Use local node_modules in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+PATH := ./node_modules/.bin:$(PATH)
 
 build:
 	webpack


### PR DESCRIPTION
There's no need to install webpack globally. Using local webpack affords both an untouched environment but also greater reproducibility of any issues.
